### PR TITLE
Added ability to pass stepConfig to steps via dbConfig.

### DIFF
--- a/src/migration.js
+++ b/src/migration.js
@@ -21,6 +21,7 @@ function Migration(dbConfig) {
     this.steps = [];
     this.migrationFiles = [];
     this.collection = dbConfig.migrationCollection;
+    this.stepConfig = dbConfig.stepConfig;
 };
 
 var validate = function(cb) {
@@ -89,7 +90,7 @@ var rollback = function(cb, error) {
                 }else{
                     cb();
                 }
-            }.bind(this)
+            }.bind(this);
         }.bind(this)),
         
         function(err, results){
@@ -116,14 +117,14 @@ Migration.prototype.migrate = function(doneCb) {
             return {
                 id : step.id,
                 status : step.status
-            }
+            };
         });
         this.db.close();
         doneCb(err, resp);
     }.bind(this);
 
     this.migrationFiles.forEach(function(path, index){
-        var _step = new StepFileReader(path).read().getStep();
+        var _step = new StepFileReader(path).read().getStep(this.stepConfig);
         _step.order = index;
         this.steps.push(_step);
     }.bind(this));
@@ -159,7 +160,7 @@ Migration.prototype.migrate = function(doneCb) {
                                 });
                             }.bind(this));
                         }
-                    }.bind(this)
+                    }.bind(this);
                 }.bind(this)),
 
                 function(err){

--- a/src/migration.js
+++ b/src/migration.js
@@ -14,14 +14,14 @@ var StepFileReader = require('./steps').Reader;
 var StepVersionCollection = require('./steps').VersionCollection;
 var utilities = require('./utils/utility-functions');
 
-function Migration(dbConfig) {
+function Migration(dbConfig, params) {
     assert.notEqual(dbConfig.migrationCollection, null);
 
     this.dbConfig = dbConfig;
     this.steps = [];
     this.migrationFiles = [];
     this.collection = dbConfig.migrationCollection;
-    this.stepConfig = dbConfig.stepConfig;
+    this.params = params || {};
 };
 
 var validate = function(cb) {
@@ -124,7 +124,7 @@ Migration.prototype.migrate = function(doneCb) {
     }.bind(this);
 
     this.migrationFiles.forEach(function(path, index){
-        var _step = new StepFileReader(path).read().getStep(this.stepConfig);
+        var _step = new StepFileReader(path).read().getStep(this.params.stepConfig);
         _step.order = index;
         this.steps.push(_step);
     }.bind(this));

--- a/src/steps/step-file-reader.js
+++ b/src/steps/step-file-reader.js
@@ -22,9 +22,9 @@ StepFile.prototype.read = function(){
     return this;
 }
 
-StepFile.prototype.getStep = function(stepConfig){
+StepFile.prototype.getStep = function(config){
     var obj = require(this.path);
-    return new Step(merge(obj, {checksum : this.checksum, stepConfig: stepConfig}));
+    return new Step(merge(obj, {checksum : this.checksum, config: config}));
 }
 
 module.exports = StepFile;

--- a/src/steps/step-file-reader.js
+++ b/src/steps/step-file-reader.js
@@ -22,9 +22,9 @@ StepFile.prototype.read = function(){
     return this;
 }
 
-StepFile.prototype.getStep = function(){
+StepFile.prototype.getStep = function(stepConfig){
     var obj = require(this.path);
-    return new Step(merge(obj, {checksum : this.checksum}));
+    return new Step(merge(obj, {checksum : this.checksum, stepConfig: stepConfig}));
 }
 
 module.exports = StepFile;

--- a/src/steps/step.js
+++ b/src/steps/step.js
@@ -14,7 +14,7 @@ function Step(obj){
     this.checksum = obj.checksum;
     this.status = statuses.notRun;
     this.order = obj.order;
-    this.config = obj.stepConfig;
+    this.config = obj.config || {};
 }
 
 module.exports = Step;

--- a/src/steps/step.js
+++ b/src/steps/step.js
@@ -14,6 +14,7 @@ function Step(obj){
     this.checksum = obj.checksum;
     this.status = statuses.notRun;
     this.order = obj.order;
+    this.config = obj.stepConfig;
 }
 
 module.exports = Step;

--- a/test/1-all-migrations-ok/migrations/1.js
+++ b/test/1-all-migrations-ok/migrations/1.js
@@ -2,6 +2,11 @@ module.exports = {
     id: '1',
 
     up: function(db, cb) {
+        // This config param should be passed in via stepConfig.
+        console.log('t1 here, config: ' + JSON.stringify(this.config));
+        if (this.config.testParam !== 123) {
+            throw new 'testParam was missing!';
+        }
         cb();
     },
 

--- a/test/1-all-migrations-ok/test.js
+++ b/test/1-all-migrations-ok/test.js
@@ -5,7 +5,7 @@ var chai = require('chai');
 var fs = require('fs');
 
 var config = require('../config');
-var migration = new Migration(config);
+var migration = new Migration(config, { stepConfig: { testParam: 1234 }});
 var dir = path.resolve(path.dirname(__filename), './migrations');
 var files = fs.readdirSync(dir);
 
@@ -16,7 +16,6 @@ var filesPath = files.map(function(file) {
 var should = chai.should;
 
 migration.add(filesPath);
-
 describe('Run migrations', function() {
     it('Must not have errors', function() {
         migration.migrate(function(err, result) {


### PR DESCRIPTION
See issue #27. I know there are some issues you might have, e.g.:
- stepConfig is currently passed into mongration as part of the dbConfig object, which is messy.  You might prefer it in a separate argument.
- stepConfig is applied to each Step as a 'config' parameter.  It could be mixed into the Step, but this would allow users to stamp on the 'id' and 'checksum' and so on.

What changes might you want to accept this pull request?
