### PR TITLE
Updated the mongodb dependency to support mongo 3.4 with auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "commander": "^2.9.0",
     "lodash.merge": "^3.3.2",
     "md5": "~2.0.0",
-    "mongodb": "~2.1.0",
+    "mongodb": "~2.2.25",
     "table-master": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently when using the library with mongodb 3.4 that has authentication enabled on it, the migration process fails. Updated mongodb to version 2.2.25. This fixes the issue when trying to run the migrations 3.4 with auth.