### PR TITLE
fix(hash): remove carriage return to prevent different hash on Windows

### DIFF
--- a/src/steps/step-file-reader.js
+++ b/src/steps/step-file-reader.js
@@ -17,6 +17,10 @@ function StepFile(path){
 
 StepFile.prototype.read = function(){
     this.content = fs.readFileSync(this.path, {encoding : 'utf8'});
+    
+    // Remove carriage return to prevent different hash on Windows
+    this.content = this.content.replace(/[\r]/g, '');
+
     this.checksum = md5(this.content);
 
     return this;


### PR DESCRIPTION
**Issue:**
On Windows the generated hash is different from Unix/Linux.

**Reason:**
The carriage return char `\r` is processed different on these systems.

**Solution:**
Remove `\r` before creating the checksum.