### PR TITLE
sort by order before validation

### DIFF
--- a/src/migration.js
+++ b/src/migration.js
@@ -26,7 +26,7 @@ function Migration(dbConfig) {
 var validate = function(cb) {
     if(this.db){
 
-        this.db.collection(this.collection).find({}, {}, {order : 1}).toArray(function(err, docs){
+        this.db.collection(this.collection).find({}, {}, {order : 1}).sort({order : 1}).toArray(function(err, docs){
             assert.equal(err, null);
             var _steps = utilities.arrayToObject(this.steps, 'id');
 


### PR DESCRIPTION
It has been observed that while running mongration on multiple dbs for multiple migration scripts , the order in which the records get saved in migration collection is not saved as per their given script sequence. Therefore while validation step , comparison for checksum goes wrong and hence throws an error. This PR is to include a safety measure, where migration db records will always be fetched as per the order sequence so that no comparison goes wrong.