### PR TITLE
Option to disable checksum comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,11 @@ If migration step *1-changed-step-sample* was succesfully run, then a developer 
 "[1-changed-step-sample] was already migrated in a different version. Current version[0685c17d538741a062c488ea776b0576] - Database version[72d9204bee94542118bd99cdde8edc0f]"
 ```
 
+If there is no way to avoid changes in already executed step files, the *checksum* comparison can be disabled:
+```javascript
+mydbMigration.disableChecksumComparison();
+```
+
 
 ### Migration Order
 

--- a/src/migration.js
+++ b/src/migration.js
@@ -21,6 +21,7 @@ function Migration(dbConfig) {
     this.steps = [];
     this.migrationFiles = [];
     this.collection = dbConfig.migrationCollection;
+    this.compareChecksums = true;
 };
 
 var validate = function(cb) {
@@ -37,7 +38,7 @@ var validate = function(cb) {
                     if(!_steps[dbStep.id] || (dbStep.order && dbStep.order != _steps[dbStep.id].order)){
                         this.steps[index].status = statuses.error;
                         cb("[" + dbStep.id + "] was already migrated on [" + dbStep.date + "] in a different order. Database order[" + dbStep.order + "] - Current migration on this order[" + this.steps[index].id + "]");
-                    }else if(dbStep.checksum != this.steps[index].checksum){
+                    }else if(this.compareChecksums && dbStep.checksum != this.steps[index].checksum){
                         this.steps[index].status = statuses.error;
                         cb("[" + dbStep.id + "] was already migrated on [" + dbStep.date + "] in a different version. Database version[" + dbStep.checksum + "] - Current version[" + this.steps[index].checksum + "]");
                     }
@@ -108,6 +109,14 @@ Migration.prototype.addAllFromPath = function(dirpath) {
     fileList.map(function(file){
         this.migrationFiles = this.migrationFiles.concat(path.join(dirpath, file));
     }.bind(this));
+};
+
+Migration.prototype.disableChecksumComparison = function () {
+    this.compareChecksums = false;
+};
+
+Migration.prototype.enableChecksumComparison = function () {
+    this.compareChecksums = true;
 };
 
 Migration.prototype.migrate = function(doneCb) {

--- a/test/migration-itest.js
+++ b/test/migration-itest.js
@@ -135,6 +135,27 @@ describe('Mongration.Migration', function() {
         });
     });
 
+    it('does ignore checksum if disabled', function (done) {
+        var migration = new Migration(config);
+        var files = getFiles('migrations/rejects-if-edited');
+        migration.add(files[0]);
+
+        migration.migrate(function (err, result) {
+            should.not.exist(err);
+            var migration2 = new Migration(config);
+            migration2.add(files[1]); // "edited": same id, different content
+            migration2.disableChecksumComparison();
+
+            migration2.migrate(function (err, result) {
+                should.not.exist(err);
+                result.should.be.an('array');
+                result.should.have.lengthOf(1);
+                result[0].should.deep.equal({ id: '1', status: 'skipped' });
+                done();
+            });
+        });
+    });
+
     // TODO: add test...
     // dunno how to trigger error "already migrated in a different order"
     it('does rollback if wrong order');

--- a/test/migrations/ignore-checksum/1.js
+++ b/test/migrations/ignore-checksum/1.js
@@ -1,0 +1,11 @@
+module.exports = {
+    id: '1',
+
+    up: function(db, callback) {
+        callback();
+    },
+
+    down: function(db, cb) {
+        cb();
+    }
+};

--- a/test/migrations/ignore-checksum/edit.js
+++ b/test/migrations/ignore-checksum/edit.js
@@ -1,0 +1,11 @@
+module.exports = {
+    id: '1',
+
+    up: function(db, cb2) {
+        cb2();
+    },
+
+    down: function(db, cb) {
+        cb();
+    }
+};


### PR DESCRIPTION
**Issue:**
Sometimes it can't be avoided to change already executed steps (caus of refactoring, found errors). In this case we need a way to disable the checksum comparison

**Solution:**
Offer functions:
 mongration.disableChecksumComparison()
 mongration.enableChecksumComparison()

Added test case
Added in documentation